### PR TITLE
Add url

### DIFF
--- a/domaines-organismes-publics.txt
+++ b/domaines-organismes-publics.txt
@@ -605,6 +605,7 @@ cvec.etudiant.gouv.fr
 cvtheque-ecologie.ader.gouv.fr
 cybermalveillance.gouv.fr
 cyberveille-sante.gouv.fr
+cyu.fr
 dares.travail-emploi.gouv.fr
 darsaintantoine.aphp.fr
 dashboard.covid19.data.gouv.fr


### PR DESCRIPTION
Ajout de CY Cergy Paris Université - cyu.fr (anciennement Université de Cergy-Pontoise - u-cergy.fr)