### PR TITLE
Merge sources/* to domains.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,61 +6,40 @@ remplissant des missions de service public.
 
 ## La liste des noms de domaines
 
-Le dossier `sources/` contient les domaines connus, qu’ils soient
-accessibles en HTTP ou non.
+Le fichier `domains.csv` contient les domaines connus, qu’ils soient
+accessibles en HTTP ou non, qu’ils exposent un MX ou non, etc.
 
-Les ajouts et suppressions s’y font soit manuellement soit via des
-scripts de collecte (voir [Contribution](#contribution)).
+C'est le seul fichier modifiable manuellement, les ajouts et
+suppressions s’y font soit manuellement soit via des scripts de
+collecte (voir [Contribution](#contribution)).
 
 
 ## La liste des URLs
 
 Le fichier `urls.txt` est une liste d’URLs basée sur les domaines du
-dossier `sources/` et répondant `200 OK` en HTTP ou en HTTPS
+fichier `domains.csv` et répondant `200 OK` en HTTP ou en HTTPS
 éventuellement après une redirection sur le **même** domaine
 (typiquement l’ajout d’un `/fr/`).
 
 Les ajouts et suppressions s’y font automatiquement, il n’est pas
 nécessaire de modifier ce fichier manuellement.
 
-Attention, cette liste étant basée sur des noms de domaines
-d’organismes publics, certaines pages d’organismes publics comme
-https://sites.google.com/site/mairiedemacey/ ne peuvent pas y figurer.
-
-
-# Les domaines inaccessibles en HTTP/HTTPS
-
-La liste des domaines qui sont dans le dossier `sources/` mais ne sont
-pas dans le fichier `urls.txt` sont inaccessibles en HTTP ou HTTPS
-(n’ont pas d’adresse IP, ne répondent pas en HTTP, répondent autre
-chose que 200 en HTTP…).
-
-Pour obtenir cette liste vous pouvez utiliser :
-
-    export LC_COLLATE=C
-    comm -13 <(cut -d/ -f3 urls.txt | sort) <(sort sources/*.txt)
-
-Il est possible de savoir ce qui cause l’inaccessibilité en regardant
-dans `domains.csv` :
-
-    $ head -n 1 domains.csv; grep mairie-valognes.fr domains.csv
-    name,http_status,https_status
-    mairie-valognes.fr,301 Moved Permanently https://www.valognes.fr/,certificate verify failed
-
-Ici on apprend qu’en HTTP le domaine redirige en HTTPS, et qu’en HTTPS
-le certificat est expiré.
+Attention, cette liste étant basée sur des **noms de domaines**
+d’organismes publics, il n'est pas possible pour des **URL**
+d’organismes publics hébergés sur des domaines privés comme
+https://sites.google.com/site/mairiedemacey/ d’y figurer.
 
 
 # Contribution
 
-Ajoutez le ou les domaines que vous connaissez dans un des fichiers du
-dossier `sources/`.
+Ajoutez le ou les domaines que vous connaissez dans le fichier
+`domains.csv`.
 
-Pour trier le fichier que vous venez de modifier, vous pouvez utiliser :
+Ce fichier doit rester trié, pour le trier automatiquement utilisez :
 
-    python scripts/sort.py sources/*.txt
+    python scripts/sort.py
 
-Pour vérifier la cohérence des fichiers :
+Pour vérifier que tout va bien avant de commit :
 
     python scripts/check.py
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -26,7 +26,8 @@ source.csv file instead of a directory with the following columns:
 
 - Nom de domaine
 - SIRET
-- Type d’établissement (à partir du découpage actuel des noms de fichier, des catégories banatic, catégorie juridique INSEE)
+- Type d’établissement (à partir du découpage actuel des noms de fichier,
+  des catégories banatic, catégorie juridique INSEE)
 - Sources (URL)
 - Scripts qui moissonnent (URL)
 
@@ -43,7 +44,9 @@ from public_domain import parse_csv_file, write_csv_file, parse_files, Domain
 
 def git(*args):
     """Just calls git, returns a list of lines."""
-    return run(["git"] + list(args), stdout=PIPE, encoding="UTF-8").stdout.splitlines()
+    return run(
+        ["git"] + list(args), stdout=PIPE, encoding="UTF-8", check=True
+    ).stdout.splitlines()
 
 
 def shelve_cache(path):
@@ -133,11 +136,11 @@ def commit_to_script(commit):
     """In case we can know which script was used to find this domain, return it."""
     message = get_commit_message(commit)
     if "CT log" in message:
-        return "scripts/import-from-ct-logs.py"
+        return "import-from-ct-logs.py"
     if "banatic" in message:
-        return "scripts/import-base-nationale-sur-les-intercommunalites.py"
+        return "import-base-nationale-sur-les-intercommunalites.py"
     if "Auracom" in message:
-        return "scripts/import-auracom-opendata.py"
+        return "import-auracom-opendata.py"
     return None
 
 
@@ -175,7 +178,8 @@ def convert_domains_csv():
     """As a reminder, the following columns are expected:
     - Nom de domaine
     - SIRET
-    - Type d’établissement (à partir du découpage actuel des noms de fichier, des catégories banatic, catégorie juridique INSEE)
+    - Type d’établissement (à partir du découpage actuel des noms de fichier,
+      des catégories banatic, catégorie juridique INSEE)
     - Sources (URL)
     - Scripts qui moissonnent (URL)
     """
@@ -183,7 +187,10 @@ def convert_domains_csv():
     commit_map = domains_and_commits()
     old_domains_csv = {domain.name: domain for domain in parse_csv_file("domains.csv")}
     from_sources_txt = sorted(parse_files(*(Path("sources").glob("*.txt"))))
-    domains = [old_domains_csv.get(domain.name, Domain(domain.name)) for domain in from_sources_txt]
+    domains = [
+        old_domains_csv.get(domain.name, Domain(domain.name))
+        for domain in from_sources_txt
+    ]
     domains.sort()
     for domain in domains:
         commit = commit_map[domain.name]

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -25,7 +25,7 @@ But this split was arbitrary, we're converting it to a single
 source.csv file instead of a directory with the following columns:
 
 - Nom de domaine
-- SIRET
+- SIREN
 - Type d’établissement (à partir du découpage actuel des noms de fichier,
   des catégories banatic, catégorie juridique INSEE)
 - Sources (URL)
@@ -177,7 +177,7 @@ def commit_to_source(commit):
 def convert_domains_csv():
     """As a reminder, the following columns are expected:
     - Nom de domaine
-    - SIRET
+    - SIREN
     - Type d’établissement (à partir du découpage actuel des noms de fichier,
       des catégories banatic, catégorie juridique INSEE)
     - Sources (URL)

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -1,0 +1,221 @@
+"""Script to convert sources/ to the 2023 format.
+
+How to run:
+
+    $ python scripts/convert.py
+    $ git rm -fr sources
+    $ git add domains.csv
+    $ git commit -m "Merge sources/* to domains.csv"
+
+The old hierarchy was:
+
+sources/
+├── academies.txt
+├── ambassades.txt
+├── aphp.txt
+├── collectivites.txt
+├── etablissements-scolaires.txt
+├── gouvfr-divers.txt
+├── hopitaux.txt
+├── nongouvfr-divers.txt
+├── sante-fr.txt
+└── universites.txt
+
+But this split was arbitrary, we're converting it to a single
+source.csv file instead of a directory with the following columns:
+
+- Nom de domaine
+- SIRET
+- Type d’établissement (à partir du découpage actuel des noms de fichier, des catégories banatic, catégorie juridique INSEE)
+- Sources (URL)
+- Scripts qui moissonnent (URL)
+
+But we almost stored the source, so we'll use git log to deduce it from commit messages.
+"""
+
+from subprocess import run, PIPE
+from pathlib import Path
+import csv
+import shelve
+import re
+
+from public_domain import parse_csv_file, parse_files, Domain
+
+
+def git(*args):
+    """Just calls git, returns a list of lines."""
+    return run(["git"] + list(args), stdout=PIPE, encoding="UTF-8").stdout.splitlines()
+
+
+def shelve_cache(path):
+    "Cache a function result to a shelf."
+
+    def cache(function):
+        def cached(*args, **kwargs):
+            with shelve.open(path) as cache:
+                key = f"{function.__name__}({args}, {kwargs})"
+                if key in cache:
+                    return cache[key]
+                result = function(*args, **kwargs)
+                cache[key] = result
+                return result
+
+        return cached
+
+    return cache
+
+
+@shelve_cache(".cache")
+def domains_and_commits():
+    """Parse `git log` to tell which commit added which domain.
+
+    Returns a mapping of domains to git commits like: {"example.com": "433f496"}
+    """
+    domain_commit_map = {}
+    commits = git("log", "--format=%H", "--reverse")
+    for commit in commits:
+        tree = git("ls-tree", "--name-only", "-r", commit)
+        for file in map(Path, tree):
+            if file.suffix in (".yml", ".py", ".md"):
+                continue
+            file = git("show", f"{commit}:{file}")
+            for line in file:
+                domain = re.split(r"[\s,]", line, maxsplit=1)[0]
+                domain = domain.split("/")[-1]
+                if domain in domain_commit_map:
+                    continue
+                domain_commit_map[domain] = commit
+    return domain_commit_map
+
+
+def domains_and_types():
+    """Build a list of domains and their types.
+
+    The type of a domain is only deduced from its location in the old hierarchy.
+    """
+    pretty_names = {
+        "academies.txt": "Académie",
+        "ambassades.txt": "Ambassade",
+        "aphp.txt": "APHP",
+        "centre-de-gestion.txt": "Centre de gestion",
+        "collectivites.txt": "Collectivité",
+        "communes.txt": "Commune",
+        "conseils-departementaux.txt": "Conseil départemental",
+        "conseils-regionaux.txt": "Conseil régional",
+        "epci.txt": "EPCI",
+        "etablissements-scolaires.txt": "Établissement scolaire",
+        "gouvfr-divers.txt": "Gouvernement",
+        "hopitaux.txt": "Hôpital",
+        "mdph-mda.txt": "MDPH ou MDA",
+        "nongouvfr-divers.txt": "",
+        "prefectures.txt": "Préfécture",
+        "sante-fr.txt": "Santé",
+        "universites.txt": "Université",
+    }
+
+    domains_and_types_map = {}
+    for file in Path("sources").glob("*.txt"):
+        for line in file.read_text().splitlines():
+            domains_and_types_map[Domain(line)] = pretty_names[file.name]
+    return domains_and_types_map
+
+
+@shelve_cache(".cache")
+def get_commit_message(sha):
+    return " ".join(git("show", "-s", "--format=%B", sha))
+
+
+@shelve_cache(".cache")
+def get_commit_author(sha):
+    return git("show", "-s", "--format=%an", sha)[0]
+
+
+def commit_to_script(commit):
+    """In case we can know which script was used to find this domain, return it."""
+    message = get_commit_message(commit)
+    if "CT log" in message:
+        return "scripts/import-from-ct-logs.py"
+    if "banatic" in message:
+        return "scripts/import-base-nationale-sur-les-intercommunalites.py"
+    if "Auracom" in message:
+        return "scripts/import-auracom-opendata.py"
+    return None
+
+
+def commit_to_source(commit):
+    """In case we can know which source was used to find this domain, return it."""
+    message = get_commit_message(commit)
+    if "https://github.com/tb0hdan/domains/blob/master/data/france" in message:
+        return "https://github.com/tb0hdan/domains/blob/master/data/france"
+    if "wikipedia" in message.lower():
+        return "Wikipedia"
+    if "ADULLACT" in message.upper():
+        return "ADULLACT"
+    if "AFNIC" in message:
+        return "AFNIC open data"
+    if "DILA" in message:
+        return "DILA open data"
+    if "wikidata" in message.lower():
+        return "Wikidata"
+    if "Auracom" in message:
+        return "Auracom open data"
+    if "https://www.data.gouv.fr/fr/datasets/listes-des-sites-gouv-fr/" in message:
+        return "https://www.data.gouv.fr/fr/datasets/listes-des-sites-gouv-fr/"
+    if "github.com/bzg/gouvfrlist" in message:
+        return "https://github.com/bzg/gouvfrlist"
+    if "banatic" in message:
+        return "Banatic"
+    if "a few domains hosted on the same IP on already known domains" in message:
+        return "DNS"
+    if "CT log" in message or "certificate transparency logs" in message:
+        return "CT logs"
+    return "Ajout manuel de " + get_commit_author(commit)
+
+
+def emit_source_csv():
+    """As a reminder, the following columns are expected:
+    - Nom de domaine
+    - SIRET
+    - Type d’établissement (à partir du découpage actuel des noms de fichier, des catégories banatic, catégorie juridique INSEE)
+    - Sources (URL)
+    - Scripts qui moissonnent (URL)
+    """
+    SIRET = None
+    types_map = domains_and_types()
+    commit_map = domains_and_commits()
+    checker_map = {domain.name: domain for domain in parse_csv_file("domains.csv")}
+    domains = parse_files(*(Path("sources").glob("*.txt")))
+    with open("domains.csv", "w") as domains_file:
+        writer = csv.writer(domains_file, lineterminator="\n")
+        writer.writerow(
+            [
+                "name",
+                "http_status",
+                "https_status",
+                "SIRET",
+                "type",
+                "sources",
+                "script",
+            ]
+        )
+        for domain in sorted(domains):
+            checks = checker_map.get(
+                domain, Domain("", None, "", None, None, None, None)
+            )
+            commit = commit_map[domain]
+            source = commit_to_source(commit)
+            script = commit_to_script(commit)
+            writer.writerow(
+                [
+                    domain.name,
+                    checks.http_status,
+                    checks.https_status,
+                    SIRET,
+                    types_map.get(domain),
+                    source,
+                    script,
+                ]
+            )
+
+
+emit_source_csv()

--- a/scripts/import-auracom-opendata.py
+++ b/scripts/import-auracom-opendata.py
@@ -8,27 +8,27 @@ from pathlib import Path
 
 import requests
 
-from sort import sort_files
+from public_domain import parse_csv_file, write_csv_file, Domain
+
 
 ROOT = Path(__file__).resolve().parent.parent
-SOURCES = ROOT / "sources"
+FILE = ROOT / "domains.csv"
 
 
 def main():
     lines = requests.get(
         "https://www.data.gouv.fr/fr/datasets/r/24848dc0-e16c-4ce8-94d9-24bc6304c9b6"
     ).text
-    with (
-        open(SOURCES / "gouvfr-divers.txt", "a", encoding="UTF-8") as gouv_fr,
-        open(SOURCES / "nongouvfr-divers.txt", "a", encoding="UTF-8") as nongouv_fr,
-    ):
-        for line in lines.splitlines():
-            domain = line.split(maxsplit=1)[0]
-            if domain.endswith(".gouv.fr"):
-                gouv_fr.write(domain + "\n")
-            else:
-                nongouv_fr.write(domain + "\n")
-    sort_files([SOURCES / "gouvfr-divers.txt", SOURCES / "nongouvfr-divers.txt"])
+    domains = parse_csv_file(FILE)
+    for line in lines.splitlines():
+        domain = Domain(
+            line,
+            script=Path(__file__).name,
+            type="Gouvernement" if line.endswith(".gouv.fr") else "",
+        )
+        if domain not in domains:
+            domains.add(domain)
+    write_csv_file(FILE, sorted(domains))
 
 
 if __name__ == "__main__":

--- a/scripts/public_domain.py
+++ b/scripts/public_domain.py
@@ -181,7 +181,7 @@ def parse_files(*files: Path) -> set[Domain]:
     }
 
 
-def parse_csv_file(domainsfile):
+def parse_csv_file(domainsfile) -> set[Domain]:
     domains = set()
     try:
         with open(domainsfile, "r", encoding="UTF-8") as domainsfile:

--- a/scripts/public_domain.py
+++ b/scripts/public_domain.py
@@ -3,13 +3,11 @@
 import argparse
 import csv
 from dataclasses import dataclass
-from datetime import date
 from functools import total_ordering
 import logging
 from pathlib import Path
 import re
 import sys
-from typing import Literal
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -62,11 +60,11 @@ NON_PUBLIC_DOMAINS = {
 @dataclass
 class Domain:
     name: str
-    source_file: Path = None
+    source_file: Path | None = None
     comment: str = ""
     http_status: str | None = None
     https_status: str | None = None
-    SIRET: str | None = None
+    SIRET: str | None = None  # pylint: disable=invalid-name
     type: str | None = None
     sources: str | None = None
     script: str | None = None
@@ -79,6 +77,7 @@ class Domain:
 
     @classmethod
     def csv_headers(cls):
+        """List of columns to generate for the CSV files."""
         return (
             "name",
             "http_status",
@@ -106,9 +105,9 @@ class Domain:
         return tuple(getattr(self, attr) for attr in self.csv_headers())
 
     @classmethod
-    def fromtuple(cls, t):
+    def fromtuple(cls, domain_tuple):
         """Usefull to read from CSV files."""
-        attrs = dict(zip(cls.csv_headers(), t))
+        attrs = dict(zip(cls.csv_headers(), domain_tuple))
         return cls(**attrs)
 
     @classmethod
@@ -254,6 +253,7 @@ def _https_status_color(domain):
 
 def main_get(args):
     """TODO: Ajouter l'historique d'un domaine en consultant le git log?"""
+
     def title(string):
         return TITLE_COLOR + string + NO_COLOR
 
@@ -272,18 +272,20 @@ def main_get(args):
             print(property("SIRET:"), domain.SIRET)
         if domain.script:
             print(property("Script:"), domain.script)
+        start_color, end_color = _http_status_color(domain), NO_COLOR
         print(
             property("HTTP:"),
-            f"http://{domain.name} {_http_status_color(domain)}{domain.http_status}{NO_COLOR}",
+            f"http://{domain.name} {start_color}{domain.http_status}{end_color}",
         )
         print(
             property("HTTPS:"),
-            f"https://{domain.name} {_https_status_color(domain)}{domain.https_status}{NO_COLOR}",
+            f"https://{domain.name} {start_color}{domain.https_status}{end_color}",
         )
         print("\n")
 
 
 def main():
+    """Pretty print domains, to use from command line."""
     args = parse_args()
     sys.exit(args.func(args))
 

--- a/scripts/public_domain.py
+++ b/scripts/public_domain.py
@@ -64,7 +64,7 @@ class Domain:
     comment: str = ""
     http_status: str | None = None
     https_status: str | None = None
-    SIRET: str | None = None  # pylint: disable=invalid-name
+    SIREN: str | None = None  # pylint: disable=invalid-name
     type: str | None = None
     sources: str | None = None
     script: str | None = None
@@ -82,7 +82,7 @@ class Domain:
             "name",
             "http_status",
             "https_status",
-            "SIRET",
+            "SIREN",
             "type",
             "sources",
             "script",
@@ -268,8 +268,8 @@ def main_get(args):
             print(property("Type:"), domain.type)
         if domain.sources:
             print(property("Source:"), domain.sources)
-        if domain.SIRET:
-            print(property("SIRET:"), domain.SIRET)
+        if domain.SIREN:
+            print(property("SIREN:"), domain.SIREN)
         if domain.script:
             print(property("Script:"), domain.script)
         start_color, end_color = _http_status_color(domain), NO_COLOR

--- a/scripts/public_domain.py
+++ b/scripts/public_domain.py
@@ -223,34 +223,6 @@ KO_COLOR = "\x1b[31m"
 NO_COLOR = "\x1b[0m"
 
 
-def _http_status_color(domain):
-    """Give an indication of the HTTP status.
-
-    green: It redirects to HTTPS.
-    yellow: It returns 200 OK, should probably redirect to HTTPS.
-    red: Other cases.
-    """
-    if domain.http_status.startswith("301") and "https" in domain.http_status:
-        return OK_COLOR
-    if domain.http_status.startswith("200"):
-        return OKISH_COLOR  # Should probably redirect to HTTPS
-    return KO_COLOR
-
-
-def _https_status_color(domain):
-    """Give an indication of the HTTPS status.
-
-    green: It returns 200 OK.
-    yellow: It returns a redirection.
-    red: Other cases.
-    """
-    if domain.https_status.startswith("200"):
-        return OK_COLOR
-    if domain.https_status.startswith("3"):
-        return OKISH_COLOR
-    return KO_COLOR
-
-
 def main_get(args):
     """TODO: Ajouter l'historique d'un domaine en consultant le git log?"""
 
@@ -272,15 +244,8 @@ def main_get(args):
             print(property("SIREN:"), domain.SIREN)
         if domain.script:
             print(property("Script:"), domain.script)
-        start_color, end_color = _http_status_color(domain), NO_COLOR
-        print(
-            property("HTTP:"),
-            f"http://{domain.name} {start_color}{domain.http_status}{end_color}",
-        )
-        print(
-            property("HTTPS:"),
-            f"https://{domain.name} {start_color}{domain.https_status}{end_color}",
-        )
+        print(property(f"http://{domain.name}:"), domain.http_status)
+        print(property(f"https://{domain.name}:"), domain.https_status)
         print("\n")
 
 

--- a/scripts/sort.py
+++ b/scripts/sort.py
@@ -1,31 +1,14 @@
-"""Just sort the given files.
+"""Just sort domains.csv."""
 
-And remove blank lines, and remove duplicates, and lowercase.
-"""
-
-import argparse
 from pathlib import Path
-from public_domain import Domain, parse_files
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("file", nargs="*", type=Path)
-    return parser.parse_args()
-
-
-def sort_files(files):
-    for file in files:
-        domains = parse_files(file)
-        file.write_text(
-            "\n".join([str(d) for d in sorted(domains) if d.name]) + "\n",
-            encoding="UTF-8",
-        )
+from public_domain import parse_csv_file, write_csv_file
 
 
 def main():
-    args = parse_args()
-    sort_files(args.file)
+    file = Path("domains.csv")
+    domains = parse_csv_file(file)
+    domains = sorted(domains)
+    write_csv_file(file, domains)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TODO :

- [x] Prendre en compte les commentaires de `sources/*.txt` (lignes avec des `#`).
- [x] Mettre à jour `check.py`
- [x] Mettre à jour `sort.py`
- [x] Mettre à jour le README.
- [x] Mettre à jour les scripts d'insertion.

Alors, j'ai pris une liberté : j'ai mergé `sources/*` **dans** `domains.csv` plutôt que créer encore un nouveau fichier (et oui je suis toujours ouvert à la discussion). Les « colonnes » sont donc :

```text
$ head -n 1 domains.csv 
name,http_status,https_status,SIREN,type,sources,script
```

J'ai versionné `scripts/convert.py` qui fait la convertion, je ne pense pas que ce soit nécessaire.

J'ai surtout besoin de relecture côté « choix des mots », dans `convert.py` j'ai :

```python
    pretty_names = {
        "academies.txt": "Académie",
        "ambassades.txt": "Ambassade",
        "aphp.txt": "APHP",
        "centre-de-gestion.txt": "Centre de gestion",
        "collectivites.txt": "Collectivité",
        "communes.txt": "Commune",
        "conseils-departementaux.txt": "Conseil départemental",
        "conseils-regionaux.txt": "Conseil régional",
        "epci.txt": "EPCI",
        "etablissements-scolaires.txt": "Établissement scolaire",
        "gouvfr-divers.txt": "Gouvernement",
        "hopitaux.txt": "Hôpital",
        "mdph-mda.txt": "MDPH ou MDA",
        "nongouvfr-divers.txt": "",
        "prefectures.txt": "Préfécture",
        "sante-fr.txt": "Santé",
        "universites.txt": "Université",
    }
```

J'ai aussi :

```python
    return "Ajout manuel de " + get_commit_author(commit)
```

Je pense que tout le monde ne veut pas voir son nom ici répété des milliers de fois, moi le premier, mais je manquais d'inspiration pour les ajouts manuels. On peut se contenter de « Ajout manuel », l'auteur est dans le git log de toutes façons ?

Pour expérimenter j'ai implémenté :

![Capture d’écran du 2023-01-04 23-14-56](https://user-images.githubusercontent.com/239510/210660225-f7b894e2-17c0-489f-af9f-27f4c4632bb8.png)

On peut imaginer une option `--json` si un jour quelqu'un veut un export json, qu'on est pas obligé de versionner.
